### PR TITLE
Updated C++11 req to C++14 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,25 @@
 language: cpp
 compiler: gcc
 before_install:
-- if [ $TRAVIS_OS_NAME == linux ]; then sudo apt-get update -qq; fi
-- if [ $TRAVIS_OS_NAME == linux ]; then sudo apt-get install -y protobuf-compiler libprotobuf-dev; fi
+- |
+    if [ $TRAVIS_OS_NAME == linux ]; then 
+        sudo apt-get update -qq; fi
+        sudo apt-get install -y protobuf-compiler libprotobuf-dev; 
+        sudo apt-get install capnproto
+    fi
 - if [ $TRAVIS_OS_NAME == osx ]; then brew update; fi
 - if [ $TRAVIS_OS_NAME == osx ]; then brew tap homebrew/versions; fi
 - if [ $TRAVIS_OS_NAME == osx ]; then brew install protobuf241; fi
 - if [ $TRAVIS_OS_NAME == osx ]; then brew link --force --overwrite protobuf241; fi
 script: 
-- if [ $TRAVIS_OS_NAME == linux ]; then ./bootstrap.sh && ./configure --with-protobuf=/usr/ && make; fi
-- if [ $TRAVIS_OS_NAME == osx ]; then ./bootstrap.sh && ./configure --with-protobuf=/usr/local/Cellar/protobuf241/2.4.1/ && make; fi
-- if [ $TRAVIS_OS_NAME == osx ]; then mv harvesttools harvest_osx; fi
-- if [ $TRAVIS_OS_NAME == linux ]; then mv harvesttools harvest_linux; fi
+- if [ $TRAVIS_OS_NAME == linux ]; then 
+  ./bootstrap.sh && ./configure --with-protobuf=/usr/ && make; 
+  mv harvesttools harvest_linux; 
+fi
+- if [ $TRAVIS_OS_NAME == osx ]; then 
+  ./bootstrap.sh && ./configure --with-protobuf=/usr/local/Cellar/protobuf241/2.4.1/ && make; 
+  mv harvesttools harvest_osx; 
+fi 
 notifications:
   email:
     recipients:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,9 @@
 language: cpp
 compiler: gcc
 before_install:
-- |
-    if [ $TRAVIS_OS_NAME == linux ]; then 
-        sudo apt-get update -qq; fi
-        sudo apt-get install -y protobuf-compiler libprotobuf-dev; 
-        sudo apt-get install capnproto
-    fi
+- if [ $TRAVIS_OS_NAME == linux ]; then sudo apt-get update -qq; fi
+- if [ $TRAVIS_OS_NAME == linux ]; then sudo apt-get install -y protobuf-compiler libprotobuf-dev; fi
+- if [ $TRAVIS_OS_NAME == linux ]; then sudo apt-get install capnproto; fi
 - if [ $TRAVIS_OS_NAME == osx ]; then brew update; fi
 - if [ $TRAVIS_OS_NAME == osx ]; then brew tap homebrew/versions; fi
 - if [ $TRAVIS_OS_NAME == osx ]; then brew install protobuf241; fi

--- a/Makefile.in
+++ b/Makefile.in
@@ -1,4 +1,4 @@
-CXXFLAGS += -std=c++11 -Isrc -I@protobuf@/include -I@capnp@/include
+CXXFLAGS += -std=c++14 -Isrc -I@protobuf@/include -I@capnp@/include
 
 UNAME_S=$(shell uname -s)
 

--- a/configure.ac
+++ b/configure.ac
@@ -29,7 +29,7 @@ then
 	AC_MSG_ERROR([Cap'n Proto compiler (capnp) not found.])
 fi
 
-CPPFLAGS="-I$with_protobuf/include -I$with_capnp/include -std=c++11"
+CPPFLAGS="-I$with_protobuf/include -I$with_capnp/include -std=c++14"
 
 AC_CHECK_HEADER(google/protobuf/stubs/common.h, [result=1], [result=0])
 


### PR DESCRIPTION
Users of Mash had [simlar issues](https://github.com/marbl/Mash/issues/98) with the current protobuf headers requiring C++14 instead of C++11. 