### PR TITLE
Fix off by one lcb list

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -7,6 +7,10 @@ ifeq ($(UNAME_S),Darwin)
 else
 	CXXFLAGS += -include src/harvest/memcpyLink.h -Wl,--wrap=memcpy
 	CFLAGS += -include src/harvest/memcpyLink.h
+	# Link the C++ runtime statically so the binary doesn't require a matching
+	# (or newer) libstdc++/libgcc on the target machine. glibc is still a
+	# runtime dependency; build on the oldest target distro for max portability.
+	STATICLIBS = -static-libgcc -static-libstdc++
 endif
 
 SOURCES=\
@@ -26,7 +30,7 @@ OBJECTS=$(SOURCES:.cpp=.o) src/harvest/pb/harvest.pb.o src/harvest/capnp/harvest
 all : harvesttools libharvest.a
 
 harvesttools : libharvest.a src/harvest/memcpyWrap.o
-	$(CXX) $(CXXFLAGS) $(CPPFLAGS) -o harvesttools src/harvest/memcpyWrap.o libharvest.a @protobuf@/lib/libprotobuf.a @capnp@/lib/libcapnp.a @capnp@/lib/libkj.a -lstdc++ -lz -lm -lpthread
+	$(CXX) $(CXXFLAGS) $(CPPFLAGS) $(STATICLIBS) -o harvesttools src/harvest/memcpyWrap.o libharvest.a @protobuf@/lib/libprotobuf.a @capnp@/lib/libcapnp.a @capnp@/lib/libkj.a -lz -lm -lpthread
 
 libharvest.a : $(OBJECTS)
 	ar -cr libharvest.a $(OBJECTS)

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,5 @@
-AC_INIT(src/harvest/harvest.cpp)
+AC_INIT
+AC_CONFIG_SRCDIR([src/harvest/harvest.cpp])
 
 AC_ARG_WITH(protobuf, [  --with-protobuf=<path/to/protobuf>     Protocol Buffers install dir (default: /usr/local/)])
 AC_ARG_WITH(capnp, [  --with-capnp=<path/to/capnp>     Cap'n Proto install dir (default: /usr/local/)])
@@ -29,7 +30,7 @@ then
 	AC_MSG_ERROR([Cap'n Proto compiler (capnp) not found.])
 fi
 
-CPPFLAGS="-I$with_protobuf/include -I$with_capnp/include -std=c++14"
+CPPFLAGS="$CPPFLAGS -I$with_protobuf/include -I$with_capnp/include -std=c++17"
 
 AC_CHECK_HEADER(google/protobuf/stubs/common.h, [result=1], [result=0])
 
@@ -55,4 +56,5 @@ fi
 AC_SUBST(protobuf, $with_protobuf)
 AC_SUBST(capnp, $with_capnp)
 
-AC_OUTPUT(Makefile)
+AC_CONFIG_FILES([Makefile])
+AC_OUTPUT

--- a/src/harvest/HarvestIO.cpp
+++ b/src/harvest/HarvestIO.cpp
@@ -208,7 +208,13 @@ bool HarvestIO::loadHarvestProtocolBuffer(const char * file)
 	GzipInputStream gz(&raw_input);
 	CodedInputStream coded_input(&gz);
 	
+	// The two-argument form (total limit, warning threshold) was removed in
+	// protobuf 3.6; newer versions take a single total-bytes limit.
+#if defined(GOOGLE_PROTOBUF_VERSION) && GOOGLE_PROTOBUF_VERSION >= 3006000
+	coded_input.SetTotalBytesLimit(INT_MAX);
+#else
 	coded_input.SetTotalBytesLimit(INT_MAX, INT_MAX);
+#endif
 	
 	if ( ! harvest.ParseFromCodedStream(&coded_input) )
 	{

--- a/src/harvest/LcbList.cpp
+++ b/src/harvest/LcbList.cpp
@@ -854,20 +854,16 @@ void LcbList::initFromXmfa(const char * file, ReferenceList * referenceList, Tra
 			
 			LcbList::Region * region = &lcb->regions[trackIndex];
 			
-			region->position = atoi(strtok(0, "-"));
-			
-			if ( mauve )
-			{
-				region->position--;
-			}
-			
-			int end = atoi(strtok(0, " "));
-			
-			if ( mauve )
-			{
-				end--;
-			}
-			
+			// XMFA coordinates are 1-based and inclusive for every format we
+			// read here (Mauve, Parsnp, MultiSNiP). Convert to 0-based
+			// internally so reference lookups (sequence[position]) and VCF
+			// output (which adds 1 back) land on the correct base. Previously
+			// only Mauve was decremented, leaving Parsnp/MultiSNiP positions
+			// one too high in the VCF and dereferencing the wrong reference base.
+			region->position = atoi(strtok(0, "-")) - 1;
+
+			int end = atoi(strtok(0, " ")) - 1;
+
 			region->length = end - region->position + 1;
 			region->reverse = *strtok(0, " ") == '-';
 			
@@ -878,9 +874,9 @@ void LcbList::initFromXmfa(const char * file, ReferenceList * referenceList, Tra
 					lcb->sequence = 0;
 					lcb->position = region->position;
 					
-					if ( end > ref.length() )
+					if ( end + 1 > ref.length() )
 					{
-						ref.resize(end, 'N');
+						ref.resize(end + 1, 'N');
 					}
 				}
 				else
@@ -1340,7 +1336,7 @@ void LcbList::writeToXmfa(ostream & out, const ReferenceList & referenceList, co
 			// >1:8230-11010 + cluster174 s1:p8230
 			
 			const LcbList::Region & region = lcb.regions.at(r);
-			int start = region.position;
+			int start = region.position + 1; // convert 0-based internal coord back to 1-based XMFA
 			int end = start + region.length - 1;
 			
 			if (r == 0)


### PR DESCRIPTION
Fixed the issue that was causing the references to be off by one when a genbank file (-g) or fasta file (-f) were given as a reference.  Going to tag and as v1.1.3